### PR TITLE
Fix a small mistyping in $VERSION (tag-release)

### DIFF
--- a/tools/tag-release
+++ b/tools/tag-release
@@ -11,7 +11,7 @@ VERSION=`$TOOL_PATH/get-version`
 
 git fetch --tags
 if [ "`git tag -l | grep $VERSION`" != "" ] ; then
-  echo "Warning: version $VERISON already exists. Aborting ..."
+  echo "Warning: version $VERSION already exists. Aborting ..."
   exit 2
 fi
 


### PR DESCRIPTION
`$VERSION` was written `$VERSOIN` in `tools/tag-release`
Not a big deal, as it was only in display, but better.
