### PR TITLE
fix error "invalid argument supplied for foreach()" for rrmdir fucntion

### DIFF
--- a/server/container/users.php
+++ b/server/container/users.php
@@ -255,11 +255,15 @@ class Container_users {
 }
 
 function rrmdir($dir) {
-    foreach (glob($dir . '/*') as $file) {
-        if(is_dir($file))
-            rrmdir($file);
-        else
-            unlink($file);
+    $files_array=glob($dir . '/*');
+    
+    if(is_array($files_array) && count($files_array)>0){
+      foreach ($files_array as $file) {
+	  if(is_dir($file))
+	      rrmdir($file);
+	  else
+	      unlink($file);
+      }
     }
     rmdir($dir);
 }


### PR DESCRIPTION
When try reopen chat  login window show javascript code because server send errors

```
Slim Application Error
The application could not run because of the following error:
Details
Code: 2
Message: Invalid argument supplied for foreach()
File: ..../server/container/users.php
Line: 258
```

Fix for this issue - check array for function     glob() 
